### PR TITLE
DAS-42: `trpc` query for filtered daily price action

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -43,6 +43,9 @@ export default function App() {
 						</Link>{" "}
 						<Link to="/register" className="[&.active]:font-bold">
 							Register
+						</Link>{" "}
+						<Link to="/price-action/daily-recap" className="[&.active]:font-bold">
+							Daily Recap
 						</Link>
 					</div>
 					<hr />

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -20,6 +20,9 @@ import { Route as RegisterImport } from './routes/register'
 
 const AboutLazyImport = createFileRoute('/about')()
 const IndexLazyImport = createFileRoute('/')()
+const PriceActionDailyRecapLazyImport = createFileRoute(
+  '/price-action/daily-recap',
+)()
 
 // Create/Update Routes
 
@@ -46,6 +49,14 @@ const IndexLazyRoute = IndexLazyImport.update({
   path: '/',
   getParentRoute: () => rootRoute,
 } as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
+
+const PriceActionDailyRecapLazyRoute = PriceActionDailyRecapLazyImport.update({
+  id: '/price-action/daily-recap',
+  path: '/price-action/daily-recap',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() =>
+  import('./routes/price-action/daily-recap.lazy').then((d) => d.Route),
+)
 
 // Populate the FileRoutesByPath interface
 
@@ -79,6 +90,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AboutLazyImport
       parentRoute: typeof rootRoute
     }
+    '/price-action/daily-recap': {
+      id: '/price-action/daily-recap'
+      path: '/price-action/daily-recap'
+      fullPath: '/price-action/daily-recap'
+      preLoaderRoute: typeof PriceActionDailyRecapLazyImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
@@ -89,6 +107,7 @@ export interface FileRoutesByFullPath {
   '/register': typeof RegisterRoute
   '/verify-me': typeof VerifyMeRoute
   '/about': typeof AboutLazyRoute
+  '/price-action/daily-recap': typeof PriceActionDailyRecapLazyRoute
 }
 
 export interface FileRoutesByTo {
@@ -96,6 +115,7 @@ export interface FileRoutesByTo {
   '/register': typeof RegisterRoute
   '/verify-me': typeof VerifyMeRoute
   '/about': typeof AboutLazyRoute
+  '/price-action/daily-recap': typeof PriceActionDailyRecapLazyRoute
 }
 
 export interface FileRoutesById {
@@ -104,14 +124,26 @@ export interface FileRoutesById {
   '/register': typeof RegisterRoute
   '/verify-me': typeof VerifyMeRoute
   '/about': typeof AboutLazyRoute
+  '/price-action/daily-recap': typeof PriceActionDailyRecapLazyRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/register' | '/verify-me' | '/about'
+  fullPaths:
+    | '/'
+    | '/register'
+    | '/verify-me'
+    | '/about'
+    | '/price-action/daily-recap'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/register' | '/verify-me' | '/about'
-  id: '__root__' | '/' | '/register' | '/verify-me' | '/about'
+  to: '/' | '/register' | '/verify-me' | '/about' | '/price-action/daily-recap'
+  id:
+    | '__root__'
+    | '/'
+    | '/register'
+    | '/verify-me'
+    | '/about'
+    | '/price-action/daily-recap'
   fileRoutesById: FileRoutesById
 }
 
@@ -120,6 +152,7 @@ export interface RootRouteChildren {
   RegisterRoute: typeof RegisterRoute
   VerifyMeRoute: typeof VerifyMeRoute
   AboutLazyRoute: typeof AboutLazyRoute
+  PriceActionDailyRecapLazyRoute: typeof PriceActionDailyRecapLazyRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -127,6 +160,7 @@ const rootRouteChildren: RootRouteChildren = {
   RegisterRoute: RegisterRoute,
   VerifyMeRoute: VerifyMeRoute,
   AboutLazyRoute: AboutLazyRoute,
+  PriceActionDailyRecapLazyRoute: PriceActionDailyRecapLazyRoute,
 }
 
 export const routeTree = rootRoute
@@ -142,7 +176,8 @@ export const routeTree = rootRoute
         "/",
         "/register",
         "/verify-me",
-        "/about"
+        "/about",
+        "/price-action/daily-recap"
       ]
     },
     "/": {
@@ -156,6 +191,9 @@ export const routeTree = rootRoute
     },
     "/about": {
       "filePath": "about.lazy.tsx"
+    },
+    "/price-action/daily-recap": {
+      "filePath": "price-action/daily-recap.lazy.tsx"
     }
   }
 }

--- a/client/src/routes/price-action/daily-recap.lazy.tsx
+++ b/client/src/routes/price-action/daily-recap.lazy.tsx
@@ -1,0 +1,72 @@
+import { trpc } from "@/lib/trpc";
+import type { PriceActionWithUpdatedAt } from "@shared/types/price-action.types";
+import { PRICE_ACTION_TABLES } from "@shared/types/table.types";
+import { createLazyFileRoute } from "@tanstack/react-router";
+
+function roundVolumeToMillions(volume: number) {
+	return (volume / 1e6).toFixed(2);
+}
+
+// TODO: search param (YearMonthDay) for the date. Default it to the latest
+// market session.
+export const Route = createLazyFileRoute("/price-action/daily-recap")({
+	component: DailyRecap
+});
+
+// TODO: this is just a placeholder for the daily recap view
+function DailyRecap() {
+	const { data: priceActionData } = trpc.priceAction.daily.flat.useQuery({
+		from: "2025-01-22",
+		to: "2025-01-23",
+		table: PRICE_ACTION_TABLES.DAILY,
+		minVolume: 1e7
+	});
+
+	const { data: groupedPriceActionData } = trpc.priceAction.daily.grouped.useQuery({
+		from: "2025-01-22",
+		to: "2025-01-23",
+		table: PRICE_ACTION_TABLES.DAILY,
+		minVolume: 1e7,
+		groupBy: "ticker"
+	});
+
+	console.log({ groupedPriceActionData });
+
+	if (!priceActionData) {
+		return null;
+	}
+
+	return (
+		<div>
+			<div
+				style={{
+					margin: "1.5rem",
+					display: "grid",
+					rowGap: "0.5rem",
+					gridTemplateColumns: "repeat(6, max-content)"
+				}}
+			>
+				{(priceActionData as PriceActionWithUpdatedAt[]).map(
+					(d: PriceActionWithUpdatedAt) => (
+						<div
+							key={d.ticker}
+							style={{
+								display: "grid",
+								gap: "0.5rem",
+								gridTemplateColumns: "subgrid",
+								gridColumn: "1 / -1"
+							}}
+						>
+							<div>{d.ticker}</div>
+							<div>{d.open}</div>
+							<div>{d.close}</div>
+							<div>{d.high}</div>
+							<div>{d.low}</div>
+							<div>{roundVolumeToMillions(+d.volume)}</div>
+						</div>
+					)
+				)}
+			</div>
+		</div>
+	);
+}

--- a/server/src/lib/data/models/price-action/filter.ts
+++ b/server/src/lib/data/models/price-action/filter.ts
@@ -6,7 +6,7 @@ import type { SQL } from "types/utility.types";
 /** Ticker filter for price action queries.
  * @note do not put this as the first condition, since it returns "AND ...". */
 export function sqlTickerFilter({ sql, tickers }: { sql: SQL; tickers: Ticker[] }) {
-	return tickers.length > 0 ? sql`and ticker = ANY(${sql(tickers)})` : sql``;
+	return tickers.length > 0 ? sql`and ticker = ANY(${sql.array(tickers)})` : sql``;
 }
 
 type TimestampFilterArgs = {

--- a/server/src/lib/data/models/price-action/filter.ts
+++ b/server/src/lib/data/models/price-action/filter.ts
@@ -1,5 +1,6 @@
 import { toTimestamp } from "@/lib/datetime/timestamp";
 import type { Datelike } from "@shared/types/utility.types";
+import dayjs from "dayjs";
 import type { Ticker } from "types/data.types";
 import type { SQL } from "types/utility.types";
 
@@ -21,6 +22,10 @@ export function sqlTimestampFilter({ sql, from, to }: TimestampFilterArgs) {
 
 	const _from = toTimestamp(from ?? 0);
 	const _to = toTimestamp(to ?? Date.now());
+
+	if (dayjs(_to).isBefore(dayjs(_from))) {
+		throw new Error("to cannot be before from");
+	}
 
 	// TODO: ensure that `to` is after `from`
 

--- a/server/src/lib/data/models/price-action/insert-price-action.ts
+++ b/server/src/lib/data/models/price-action/insert-price-action.ts
@@ -1,10 +1,10 @@
 import { sqlConnection } from "@/db/init";
+import type {
+	PriceAction,
+	PriceActionWithUpdatedAt,
+} from "@shared/types/price-action.types";
+import { priceActionWithUpdatedAtSchema } from "@shared/types/price-action.types";
 import { PRICE_ACTION_TABLES } from "@shared/types/table.types";
-import {
-	priceActionWithUpdatedAtSchema,
-	type PriceAction,
-	type PriceActionWithUpdatedAt,
-} from "types/price-action.types";
 import { type QueryFunction } from "types/utility.types";
 
 /** Insert a number of price action entries into the database.

--- a/server/src/lib/data/models/price-action/mock.ts
+++ b/server/src/lib/data/models/price-action/mock.ts
@@ -1,4 +1,4 @@
-import type { PriceAction } from "types/price-action.types";
+import type { PriceAction } from "@shared/types/price-action.types";
 
 function mockPriceAction(index: number): PriceAction {
 	return {

--- a/server/src/lib/data/models/price-action/parse-and-insert-price-action.ts
+++ b/server/src/lib/data/models/price-action/parse-and-insert-price-action.ts
@@ -2,8 +2,8 @@ import { sqlConnection } from "@/db/init";
 import { insertPriceAction } from "@/lib/data/models/price-action/insert-price-action";
 import { parseGroupedDailyToPriceAction } from "@/lib/data/models/price-action/parse-polygon";
 import { fetchGroupedDaily } from "@/lib/polygon/endpoints/grouped-daily";
+import type { PriceAction } from "@shared/types/price-action.types";
 import type { YearMonthDay } from "types/data.types";
-import type { PriceAction } from "types/price-action.types";
 import type { QueryFunction } from "types/utility.types";
 import { fileURLToPath } from "url";
 

--- a/server/src/lib/data/models/price-action/parse-polygon.ts
+++ b/server/src/lib/data/models/price-action/parse-polygon.ts
@@ -1,7 +1,7 @@
 import type { fetchAggregate } from "@/lib/polygon/endpoints/aggregate";
 import type { fetchGroupedDaily } from "@/lib/polygon/endpoints/grouped-daily";
 import type { OHLCV } from "@/lib/polygon/polygon.types";
-import type { PriceAction } from "types/price-action.types";
+import type { PriceAction } from "@shared/types/price-action.types";
 import { typedObjectEntries } from "types/utility.types";
 
 type Aggregate = Awaited<ReturnType<typeof fetchAggregate>>;

--- a/server/src/lib/data/models/price-action/query-price-action.ts
+++ b/server/src/lib/data/models/price-action/query-price-action.ts
@@ -9,32 +9,17 @@ import {
 	type PriceAction,
 } from "@shared/types/price-action.types";
 import { PRICE_ACTION_TABLES } from "@shared/types/table.types";
-import type { Datelike, Nullable } from "@shared/types/utility.types";
-import type { Ticker } from "types/data.types";
+import type { Nullable } from "@shared/types/utility.types";
+import type {
+	FlatPriceActionQuery,
+	GroupedPriceActionQuery,
+} from "types/price-action.types";
 import type { QueryFunction } from "types/utility.types";
 
-// TODO: instead of using this type, infer it from the zod validator
-export type QueryPriceActionFlatArgs = {
-	limit?: number;
-	tickers?: Ticker[];
-	minVolume?: number;
-	table?: `${PRICE_ACTION_TABLES}`;
-	// everything below is not yet implemented
-	from?: Datelike; // TODO: refine this type
-	to?: Datelike; // TODO: refine this type
-};
-
-// TODO: same as above, infer this from zod validator
-export type QueryPriceActionGroupedArgs = QueryPriceActionFlatArgs & {
-	groupBy: "ticker" | "timestamp"; // TODO: refine this type
-};
-
 /** Queries price action rows from the database using the given constraints.
- * Does not group or parse the data in any way.
- * @todo make sure from cannot be after to? (same goes for next function, and
- * also the typing, also for the resolver) */
+ * Does not group or parse the data in any way. */
 export const queryPriceActionFlat: QueryFunction<
-	QueryPriceActionFlatArgs,
+	FlatPriceActionQuery,
 	PriceActionWithUpdatedAt[]
 > = async ({
 	sql = sqlConnection,
@@ -56,12 +41,14 @@ export const queryPriceActionFlat: QueryFunction<
 	return rows.map((row) => priceActionWithUpdatedAtSchema.parse(row));
 };
 
+type QueryResult = [{ price_action: Record<string, PriceActionWithUpdatedAt[]> }?];
+
 /** Query price action rows and group them by `timestamp` or `ticker`.
  * When grouping by timestamps, the returned keys (timestamps) will be integer
  * unix ms values. */
 export const queryPriceActionGrouped: QueryFunction<
-	QueryPriceActionGroupedArgs,
-	Nullable<Record<string, PriceActionWithUpdatedAt[]>>
+	GroupedPriceActionQuery,
+	Nullable<Map<string, PriceActionWithUpdatedAt[]>>
 > = async ({
 	sql = sqlConnection,
 	limit = 1e4, // 10_000 row limit by default to prevent accidentally fetching 100 million rows. 😀
@@ -73,8 +60,8 @@ export const queryPriceActionGrouped: QueryFunction<
 	groupBy,
 }) => {
 	// query price_action_1d, and use json agg or something to group the rows by ticker
-	const [result] = await sql<[{ price_action: Record<string, PriceAction[]> }]>`
-      SELECT jsonb_object_agg(${sql(groupBy)}, price_actions) as price_action
+	const [result] =
+		await sql<QueryResult>`SELECT jsonb_object_agg(${sql(groupBy)}, price_actions) as price_action
       FROM (
          SELECT 
             ${
@@ -93,14 +80,22 @@ export const queryPriceActionGrouped: QueryFunction<
       ) AS subquery;
    `;
 
-	if (groupBy === "timestamp") {
-		return Object.entries(result.price_action).reduce((acc, [key, value]) => {
-			const mappedTimestamp = Number(key).toFixed(0);
-			return { ...acc, [mappedTimestamp]: value };
-		}, {});
+	if (!result?.price_action) {
+		return null;
 	}
 
-	return result.price_action;
+	if (groupBy === "timestamp") {
+		const hashObject = Object.entries(result.price_action).reduce(
+			(acc, [key, value]) => {
+				const mappedTimestamp = Number(key).toFixed(0);
+				return { ...acc, [mappedTimestamp]: value };
+			},
+			{},
+		);
+		return new Map(Object.entries(hashObject));
+	}
+
+	return new Map(Object.entries(result.price_action));
 };
 
 /** Queries the unique timestamps (as unix milliseconds) from a price action table. */

--- a/server/src/lib/data/models/price-action/test/insert-price-action.test.ts
+++ b/server/src/lib/data/models/price-action/test/insert-price-action.test.ts
@@ -1,7 +1,7 @@
 import { sqlConnection } from "@/db/init";
 import { insertPriceAction } from "@/lib/data/models/price-action/insert-price-action";
 import { mockManyPriceActionRows } from "@/lib/data/models/price-action/mock";
-import { priceActionWithUpdatedAtSchema } from "types/price-action.types";
+import { priceActionWithUpdatedAtSchema } from "@shared/types/price-action.types";
 
 describe("insertPriceAction", () => {
 	it("should insert a single row", async () => {

--- a/server/src/lib/data/models/price-action/test/parse-and-insert-price-action.test.ts
+++ b/server/src/lib/data/models/price-action/test/parse-and-insert-price-action.test.ts
@@ -3,8 +3,8 @@ import {
 	fetchParseAndInsertGroupedDaily,
 	removeParsedDataFile,
 } from "@/lib/data/models/price-action/parse-and-insert-price-action";
+import { priceActionWithUpdatedAtSchema } from "@shared/types/price-action.types";
 import fs from "fs/promises";
-import { priceActionWithUpdatedAtSchema } from "types/price-action.types";
 
 describe("parseAndInsertPriceAction", () => {
 	it("should parse and insert price action", async () => {

--- a/server/src/lib/data/models/price-action/test/query-price-action.test.ts
+++ b/server/src/lib/data/models/price-action/test/query-price-action.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { sqlConnection } from "@/db/init";
 import { insertPriceAction } from "@/lib/data/models/price-action/insert-price-action";
 import { mockManyPriceActionRows } from "@/lib/data/models/price-action/mock";
@@ -6,7 +7,7 @@ import {
 	queryPriceActionGrouped,
 	queryTimestamps,
 } from "@/lib/data/models/price-action/query-price-action";
-import { priceActionWithUpdatedAtSchema } from "types/price-action.types";
+import { priceActionWithUpdatedAtSchema } from "@shared/types/price-action.types";
 
 describe("queryPriceAction", () => {
 	describe("flat", () => {
@@ -52,9 +53,9 @@ describe("queryPriceAction", () => {
 					groupBy: groupBy as "ticker" | "timestamp",
 				});
 
-				expect(Object.keys(rows)).toContain(key);
+				expect(Object.keys(rows!)).toContain(key);
 
-				const parsed = priceActionWithUpdatedAtSchema.safeParse(rows[key].at(0));
+				const parsed = priceActionWithUpdatedAtSchema.safeParse(rows![key].at(0));
 				expect(parsed.success).toBe(true);
 
 				await sql`rollback`;

--- a/server/src/lib/data/models/price-action/test/query-price-action.test.ts
+++ b/server/src/lib/data/models/price-action/test/query-price-action.test.ts
@@ -53,9 +53,11 @@ describe("queryPriceAction", () => {
 					groupBy: groupBy as "ticker" | "timestamp",
 				});
 
-				expect(Object.keys(rows!)).toContain(key);
+				expect(Array.from(rows!.keys())).toContain(key);
 
-				const parsed = priceActionWithUpdatedAtSchema.safeParse(rows![key].at(0));
+				const parsed = priceActionWithUpdatedAtSchema.safeParse(
+					rows!.get(key)!.at(0),
+				);
 				expect(parsed.success).toBe(true);
 
 				await sql`rollback`;

--- a/server/src/lib/trpc.ts
+++ b/server/src/lib/trpc.ts
@@ -3,9 +3,15 @@ import { publicProcedure } from "@/lib/trpc/procedures/public.procedure";
 import { login } from "@/lib/trpc/resolvers/login.resolver";
 import { logout } from "@/lib/trpc/resolvers/logout.resolver";
 import { me } from "@/lib/trpc/resolvers/me.resolver";
+import {
+	flatDailyPriceActionResolver,
+	groupedDailyPriceActionResolver,
+} from "@/lib/trpc/resolvers/price-action/daily.resolver";
 import { register } from "@/lib/trpc/resolvers/register.resolver";
 import { verifyMe } from "@/lib/trpc/resolvers/verify-me.resolver";
 import { t } from "@/lib/trpc/trpc-context";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import superjson from "superjson";
 import { z } from "zod";
 
 export const appRouter = t.router({
@@ -35,6 +41,27 @@ export const appRouter = t.router({
 		register,
 		verifyMe,
 	},
+	priceAction: {
+		daily: {
+			flat: flatDailyPriceActionResolver,
+			grouped: groupedDailyPriceActionResolver,
+		},
+	},
 });
 
 export type AppRouter = typeof appRouter;
+
+export const proxyClient = createTRPCClient<AppRouter>({
+	links: [
+		httpBatchLink({
+			transformer: superjson,
+			url: "http://localhost:5000/api/trpc", // TODO: needs to match what we use in the client, I guess
+			fetch(url, options) {
+				return fetch(url, {
+					...options,
+					credentials: "include",
+				});
+			},
+		}),
+	],
+});

--- a/server/src/lib/trpc/resolvers/price-action/daily.resolver.ts
+++ b/server/src/lib/trpc/resolvers/price-action/daily.resolver.ts
@@ -1,0 +1,65 @@
+import {
+	queryPriceActionFlat,
+	queryPriceActionGrouped,
+} from "@/lib/data/models/price-action/query-price-action";
+import { publicProcedure } from "@/lib/trpc/procedures/public.procedure";
+import { priceActionWithUpdatedAtSchema } from "@shared/types/price-action.types";
+import { PRICE_ACTION_TABLES } from "@shared/types/table.types";
+import { datelike } from "@shared/types/zod.utility.types";
+import { z } from "zod";
+
+/*
+   If we want to refine the typing to make "from", "to", or "both" required, we can
+   use something like this:
+      const schema = z.object({
+      email: z.string().optional(),
+      username: z.string().optional(),
+      // other properties here
+      })
+      .and(z.union([
+      z.object({email: z.undefined(), username: z.string()}),
+      z.object({email: z.string(), username: z.undefined()}),
+      z.object({email: z.string(), username: z.string()}),
+      ], {errorMap: (issue, ctx) => ({message: "Either email or username must be
+      filled in"})}));
+      which I found in this discussion:
+      https://github.com/colinhacks/zod/issues/61#issuecomment-1534255967 
+
+*/
+
+/** Validator that matches QueryPriceActionFlatArgs | QueryPriceActionGroupedArgs
+ * The difference being that "from" and "to" are both required. I might change
+ * my mind on this. */
+export const flatPriceActionQuerySchema = z.object({
+	limit: z.number().optional().default(1e4),
+	tickers: z.array(z.string()).optional(),
+	minVolume: z.number().optional().default(0),
+	table: z.nativeEnum(PRICE_ACTION_TABLES),
+	from: datelike,
+	to: datelike,
+});
+export type FlatPriceActionQuery = z.infer<typeof flatPriceActionQuerySchema>;
+
+export const groupedPriceActionQuerySchema = flatPriceActionQuerySchema.extend({
+	groupBy: z.union([z.literal("ticker"), z.literal("timestamp")]),
+});
+export type GroupedPriceActionQuery = z.infer<typeof groupedPriceActionQuerySchema>;
+
+export const flatDailyPriceActionResolver = publicProcedure
+	.input(flatPriceActionQuerySchema)
+	.output(z.array(priceActionWithUpdatedAtSchema))
+	.query(async (opts) => {
+		return await queryPriceActionFlat({
+			...opts.input,
+		});
+	});
+
+export const groupedDailyPriceActionResolver = publicProcedure
+	.input(groupedPriceActionQuerySchema)
+	.output(z.record(z.string(), z.array(priceActionWithUpdatedAtSchema)).nullable())
+	.query(async (opts) => {
+		return await queryPriceActionGrouped({
+			...opts.input,
+			groupBy: opts.input.groupBy,
+		});
+	});

--- a/server/src/lib/trpc/resolvers/price-action/daily.resolver.ts
+++ b/server/src/lib/trpc/resolvers/price-action/daily.resolver.ts
@@ -10,9 +10,8 @@ import {
 } from "types/price-action.types";
 import { z } from "zod";
 
-/*
-   If we want to refine the typing to make "from", "to", or "both" required, we can
-   use something like this:
+/* If we want to refine the typing to make "from", "to", or "both" required, we can
+   use a pattern like this:
       const schema = z.object({
       email: z.string().optional(),
       username: z.string().optional(),
@@ -25,9 +24,7 @@ import { z } from "zod";
       ], {errorMap: (issue, ctx) => ({message: "Either email or username must be
       filled in"})}));
       which I found in this discussion:
-      https://github.com/colinhacks/zod/issues/61#issuecomment-1534255967 
-
-*/
+      https://github.com/colinhacks/zod/issues/61#issuecomment-1534255967 */
 
 export const flatDailyPriceActionResolver = publicProcedure
 	.input(flatPriceActionQuerySchema)

--- a/server/src/lib/trpc/resolvers/price-action/test/daily.resolver.test.ts
+++ b/server/src/lib/trpc/resolvers/price-action/test/daily.resolver.test.ts
@@ -1,0 +1,153 @@
+import { formatToYearMonthDay } from "@/lib/datetime/timestamp";
+import { proxyClient } from "@/lib/trpc";
+import {
+	flatPriceActionQuerySchema,
+	groupedPriceActionQuerySchema,
+	type FlatPriceActionQuery,
+} from "@/lib/trpc/resolvers/price-action/daily.resolver";
+import { priceActionWithUpdatedAtSchema } from "@shared/types/price-action.types";
+import { PRICE_ACTION_TABLES } from "@shared/types/table.types";
+import dayjs from "dayjs";
+
+describe("flatDailyPriceActionResolver", () => {
+	it("should make a query with the proper limit", async () => {
+		const input: FlatPriceActionQuery = {
+			limit: 10,
+			tickers: [],
+			minVolume: 0,
+			table: PRICE_ACTION_TABLES.DAILY,
+			from: "2025-01-22",
+			to: "2025-01-23",
+		};
+		const output = await proxyClient.priceAction.daily.flat.query(input);
+		expect(output.length).toBe(10);
+	});
+	it("should make a query with the proper tickers", async () => {
+		const input: FlatPriceActionQuery = {
+			limit: 1e4,
+			tickers: ["NVDA", "MSFT"],
+			minVolume: 0,
+			table: PRICE_ACTION_TABLES.DAILY,
+			from: "2025-01-22",
+			to: "2025-01-23",
+		};
+
+		const output = await proxyClient.priceAction.daily.flat.query(input);
+		expect(output.length).toBe(2);
+		expect(priceActionWithUpdatedAtSchema.parse(output[0])).toEqual(
+			expect.objectContaining({ ticker: "MSFT" }),
+		);
+	});
+	it("should return empty list when querying the future", async () => {
+		const input: FlatPriceActionQuery = {
+			limit: 1e4,
+			tickers: ["NVDA", "MSFT"],
+			minVolume: 0,
+			table: PRICE_ACTION_TABLES.DAILY,
+			from: formatToYearMonthDay(dayjs().add(1, "day").toDate()),
+			to: formatToYearMonthDay(dayjs().add(2, "day").toDate()),
+		};
+
+		const output = await proxyClient.priceAction.daily.flat.query(input);
+		expect(output.length).toBe(0);
+	});
+	it("should filter groupBy from input object", async () => {
+		const input = {
+			limit: 1e4,
+			tickers: ["NVDA", "MSFT"],
+			minVolume: 0,
+			table: PRICE_ACTION_TABLES.DAILY,
+			from: formatToYearMonthDay(dayjs().add(1, "day").toDate()),
+			to: formatToYearMonthDay(dayjs().add(2, "day").toDate()),
+			groupBy: "ticker",
+		};
+
+		expect(flatPriceActionQuerySchema.safeParse(input)).not.toEqual(
+			expect.objectContaining({ groupBy: "ticker" }),
+		);
+	});
+});
+
+describe("groupedDailyPriceActionResolver", () => {
+	it("should make a query with the proper limit", async () => {
+		const input = {
+			limit: 10,
+			tickers: [],
+			minVolume: 0,
+			table: PRICE_ACTION_TABLES.DAILY,
+			from: "2025-01-22",
+			to: "2025-01-23",
+			groupBy: "ticker" as const,
+		};
+		const output = await proxyClient.priceAction.daily.grouped.query(input);
+		expect(output).toBeDefined();
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		expect(Object.keys(output!).length).toBe(10);
+	});
+	it("should make a query with the proper tickers", async () => {
+		const input = {
+			limit: 10,
+			tickers: ["MSFT", "NVDA"],
+			minVolume: 0,
+			table: PRICE_ACTION_TABLES.DAILY,
+			from: "2025-01-21", // query multiple days
+			to: "2025-01-23", // ^
+			groupBy: "ticker" as const,
+		};
+		const output = await proxyClient.priceAction.daily.grouped.query(input);
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		expect(Object.keys(output!).length).toBe(2);
+	});
+
+	it("should return empty object when querying the future", async () => {
+		const input = {
+			limit: 10,
+			tickers: ["MSFT", "NVDA"],
+			minVolume: 0,
+			table: PRICE_ACTION_TABLES.DAILY,
+			from: formatToYearMonthDay(dayjs().add(1, "day").toDate()),
+			to: formatToYearMonthDay(dayjs().add(2, "day").toDate()),
+			groupBy: "ticker" as const,
+		};
+		const output = await proxyClient.priceAction.daily.grouped.query(input);
+		expect(output).toBe(null);
+	});
+
+	it("should not filter out groupBy from input object", async () => {
+		const input = {
+			limit: 1e4,
+			tickers: ["NVDA", "MSFT"],
+			minVolume: 0,
+			table: PRICE_ACTION_TABLES.DAILY,
+			from: formatToYearMonthDay(dayjs().add(1, "day").toDate()),
+			to: formatToYearMonthDay(dayjs().add(2, "day").toDate()),
+			groupBy: "ticker",
+		};
+
+		expect(groupedPriceActionQuerySchema.parse(input)).toEqual(
+			expect.objectContaining({ groupBy: "ticker" }),
+		);
+	});
+
+	it("should query by timestamp", async () => {
+		const input = {
+			limit: 1e4,
+			tickers: ["NVDA", "MSFT"],
+			minVolume: 0,
+			table: PRICE_ACTION_TABLES.DAILY,
+			from: "2025-01-21",
+			to: "2025-01-22",
+			groupBy: "timestamp" as const,
+		};
+
+		const output = await proxyClient.priceAction.daily.grouped.query(input);
+		console.log({ output });
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		expect(Object.keys(output!).length).toBe(1);
+
+		input.to = formatToYearMonthDay(dayjs("2025-01-21").add(2, "day").toDate());
+		const output2 = await proxyClient.priceAction.daily.grouped.query(input);
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		expect(Object.keys(output2!).length).toBe(2);
+	});
+});

--- a/server/src/lib/trpc/resolvers/price-action/test/daily.resolver.test.ts
+++ b/server/src/lib/trpc/resolvers/price-action/test/daily.resolver.test.ts
@@ -1,13 +1,13 @@
 import { formatToYearMonthDay } from "@/lib/datetime/timestamp";
 import { proxyClient } from "@/lib/trpc";
-import {
-	flatPriceActionQuerySchema,
-	groupedPriceActionQuerySchema,
-	type FlatPriceActionQuery,
-} from "@/lib/trpc/resolvers/price-action/daily.resolver";
 import { priceActionWithUpdatedAtSchema } from "@shared/types/price-action.types";
 import { PRICE_ACTION_TABLES } from "@shared/types/table.types";
 import dayjs from "dayjs";
+import type { FlatPriceActionQuery } from "types/price-action.types";
+import {
+	flatPriceActionQuerySchema,
+	groupedPriceActionQuerySchema,
+} from "types/price-action.types";
 
 describe("flatDailyPriceActionResolver", () => {
 	it("should make a query with the proper limit", async () => {
@@ -82,7 +82,7 @@ describe("groupedDailyPriceActionResolver", () => {
 		const output = await proxyClient.priceAction.daily.grouped.query(input);
 		expect(output).toBeDefined();
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		expect(Object.keys(output!).length).toBe(10);
+		expect(output?.size).toBe(10);
 	});
 	it("should make a query with the proper tickers", async () => {
 		const input = {
@@ -96,10 +96,10 @@ describe("groupedDailyPriceActionResolver", () => {
 		};
 		const output = await proxyClient.priceAction.daily.grouped.query(input);
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		expect(Object.keys(output!).length).toBe(2);
+		expect(output?.size).toBe(2);
 	});
 
-	it("should return empty object when querying the future", async () => {
+	it("should return null when querying the future", async () => {
 		const input = {
 			limit: 10,
 			tickers: ["MSFT", "NVDA"],
@@ -110,7 +110,7 @@ describe("groupedDailyPriceActionResolver", () => {
 			groupBy: "ticker" as const,
 		};
 		const output = await proxyClient.priceAction.daily.grouped.query(input);
-		expect(output).toBe(null);
+		expect(output).toBeNull();
 	});
 
 	it("should not filter out groupBy from input object", async () => {
@@ -143,11 +143,11 @@ describe("groupedDailyPriceActionResolver", () => {
 		const output = await proxyClient.priceAction.daily.grouped.query(input);
 		console.log({ output });
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		expect(Object.keys(output!).length).toBe(1);
+		expect(output?.size).toBe(1);
 
 		input.to = formatToYearMonthDay(dayjs("2025-01-21").add(2, "day").toDate());
 		const output2 = await proxyClient.priceAction.daily.grouped.query(input);
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		expect(Object.keys(output2!).length).toBe(2);
+		expect(output2?.size).toBe(2);
 	});
 });

--- a/server/types/price-action.types.ts
+++ b/server/types/price-action.types.ts
@@ -1,23 +1,5 @@
 import type { OHLCV } from "@/lib/polygon/polygon.types";
-import { datelike, numeric } from "@shared/types/zod.utility.types";
-import { z } from "zod";
-
-export const priceActionSchema = z.object({
-	ticker: z.string(),
-	timestamp: datelike, // unix ms timestamp, or date, depending on whether we parse inside the query
-	open: numeric(6),
-	close: numeric(6),
-	high: numeric(6),
-	low: numeric(6),
-	volume: numeric(2),
-});
-
-export const priceActionWithUpdatedAtSchema = priceActionSchema.extend({
-	updated_at: datelike, // same note as with `timestamp` in `priceActionSchema`
-});
-
-export type PriceAction = z.infer<typeof priceActionSchema>;
-export type PriceActionWithUpdatedAt = z.infer<typeof priceActionWithUpdatedAtSchema>;
+import type { PriceAction } from "@shared/types/price-action.types";
 
 const polygonToPriceAction = {
 	ticker: "T",

--- a/server/types/price-action.types.ts
+++ b/server/types/price-action.types.ts
@@ -1,5 +1,9 @@
 import type { OHLCV } from "@/lib/polygon/polygon.types";
 import type { PriceAction } from "@shared/types/price-action.types";
+import { PRICE_ACTION_TABLES } from "@shared/types/table.types";
+import { datelike } from "@shared/types/zod.utility.types";
+import dayjs from "dayjs";
+import { z } from "zod";
 
 const polygonToPriceAction = {
 	ticker: "T",
@@ -14,3 +18,39 @@ const polygonToPriceAction = {
 export const polygonPriceActionMap = new Map<keyof PriceAction, keyof OHLCV>(
 	Object.entries(polygonToPriceAction) as [keyof PriceAction, keyof OHLCV][],
 );
+
+const dateRangeSchema = z
+	.object({
+		from: z.optional(datelike),
+		to: z.optional(datelike),
+	})
+	.superRefine(({ from, to }, ctx) => {
+		if (from && to && dayjs(from).isAfter(dayjs(to))) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "from cannot be after to",
+				path: ["from"],
+			});
+		}
+	});
+
+/**
+ * @todo the actual database query considers from and to optional, but this
+ * consider them both required. See note in daily.resolver.ts on this.
+ */
+export const flatPriceActionQuerySchema = z
+	.object({
+		limit: z.optional(z.number().default(1e4)),
+		tickers: z.optional(z.array(z.string())),
+		minVolume: z.optional(z.number().default(0)),
+		table: z.optional(z.nativeEnum(PRICE_ACTION_TABLES)),
+	})
+	.and(dateRangeSchema);
+export type FlatPriceActionQuery = z.infer<typeof flatPriceActionQuerySchema>;
+
+export const groupedPriceActionQuerySchema = flatPriceActionQuerySchema.and(
+	z.object({
+		groupBy: z.union([z.literal("ticker"), z.literal("timestamp")]),
+	}),
+);
+export type GroupedPriceActionQuery = z.infer<typeof groupedPriceActionQuerySchema>;

--- a/shared/src/types/price-action.types.ts
+++ b/shared/src/types/price-action.types.ts
@@ -1,0 +1,21 @@
+import { datelike, numeric } from "@shared/types/zod.utility.types";
+import { z } from "zod";
+
+export const priceActionSchema = z.object({
+	ticker: z.string(),
+	timestamp: datelike, // unix ms timestamp, or date, depending on whether we parse inside the query
+	open: numeric(6),
+	close: numeric(6),
+	high: numeric(6),
+	low: numeric(6),
+	volume: numeric(2),
+});
+
+export const priceActionWithUpdatedAtSchema = priceActionSchema.extend({
+	updated_at: datelike, // same note as with `timestamp` in `priceActionSchema`
+});
+
+export type PriceAction = z.infer<typeof priceActionSchema>;
+export type PriceActionWithUpdatedAt = z.infer<
+	typeof priceActionWithUpdatedAtSchema
+>;


### PR DESCRIPTION
## Changelog
- move some types from `/server` to `/shared`. 
  - Even though the client has access to `/server`, try to always put shared code in `/shared`. Eventually we'll streamline the containers so that the client only takes the trpc stuff from the server.
- implement trpc queries and tests for daily price action
  - There was no way for the server to directly call trpc procedures yet, so I copied the config from the client into a `createTRPCClient` call. Only difference between client and server calls is the usage of the `react-query` wrapper on the client.